### PR TITLE
doc: update the download link of alci-iso-pure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ sh lilacin
 
 #### How to install Arch Linux? (the quick way)
 
-- [arcolinux/alci-iso-pure](//osdn.net/projects/alci/releases/p17534)
+- [arcolinux/alci-iso-pure](//alci.online/downloads)
 - [archlinux/archinstall](//github.com/archlinux/archinstall)
 - [MatMoul/archfi](//github.com/MatMoul/archfi)


### PR DESCRIPTION
The most recent release on osdn is archlinux-2021.02.09-x86_64.iso, which has not been updated for a long time.