### PR TITLE
DOC: helmuthdu/aui as a quick way to install Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ sh lilacin
 - [arcolinux/alci-iso-pure](//alci.online/downloads)
 - [archlinux/archinstall](//github.com/archlinux/archinstall)
 - [MatMoul/archfi](//github.com/MatMoul/archfi)
+- [helmuthdu/aui](//github.com/helmuthdu/aui)


### PR DESCRIPTION
Mention the URL of the repository helmuthdu/aui in the readme file as another way to quickly install Archlinux.